### PR TITLE
bump fedora from 35 to 36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 RUN dnf -y --setopt=install_weak_deps=False install \
         borgbackup \


### PR DESCRIPTION
This also updates Borg to version 1.2: https://www.borgbackup.org/releases/borg-1.2.html