### PR TITLE
Fix issue with SSHFS_PASSWORD containing special chars

### DIFF
--- a/borg-backup.sh
+++ b/borg-backup.sh
@@ -30,7 +30,7 @@ if [ -n "${SSHFS:-}" ]; then
         SSHFS_IDENTITY_FILE=''
     fi
     if [ -n "${SSHFS_PASSWORD:-}" ]; then
-        SSHFS_PASSWORD="echo ${SSHFS_PASSWORD} |"
+        SSHFS_PASSWORD="echo \"${SSHFS_PASSWORD}\" |"
         SSHFS_PASSWORD_OPT='-o password_stdin'
     else
         SSHFS_PASSWORD=''


### PR DESCRIPTION
Contributing fix to issue: https://github.com/pschiffe/docker-borg/issues/16