### PR TITLE
Add GLOB in addition to PREFIX because PREFIX is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ Description of all accepted environment variables follows.
 
 **PRUNE** - if set, prune the repository after backup. Empty by default. [More info](https://borgbackup.readthedocs.io/en/stable/usage.html#borg-prune)
 
-**PRUNE_PREFIX** - filter data to prune by prefix of the archive. Empty by default - prune all data
+**GLOB** - filter data to prune by prefix of the archive. Empty by default - prune all data 
+
+**PRUNE_PREFIX** - filter data to prune by prefix of the archive. Empty by default - prune all data (DEPRECATED, use **GLOB** instead)
 
 **KEEP_DAILY** - keep specified number of daily backups. Defaults to 7
 

--- a/borg-backup.sh
+++ b/borg-backup.sh
@@ -144,6 +144,11 @@ if [ -n "${PRUNE:-}" ]; then
     else
         PRUNE_PREFIX=''
     fi
+    if [ -n "${GLOB:-}" ]; then
+        GLOB="--glob-archives=${GLOB}"
+    else
+        GLOB=''
+    fi
     if [ -z "${KEEP_DAILY:-}" ]; then
         KEEP_DAILY=7
     fi
@@ -155,7 +160,7 @@ if [ -n "${PRUNE:-}" ]; then
     fi
 
     # shellcheck disable=SC2086
-    borg prune --stats --show-rc $LOGGING_LEVEL $PROGRESS $PRUNE_PREFIX --keep-daily=$KEEP_DAILY --keep-weekly=$KEEP_WEEKLY --keep-monthly=$KEEP_MONTHLY
+    borg prune --stats --show-rc $LOGGING_LEVEL $PROGRESS $PRUNE_PREFIX $GLOB --keep-daily=$KEEP_DAILY --keep-weekly=$KEEP_WEEKLY --keep-monthly=$KEEP_MONTHLY
     # shellcheck disable=SC2086
     borg compact --cleanup-commits --show-rc $LOGGING_LEVEL $PROGRESS
 fi


### PR DESCRIPTION
For `borg prune`, `--prefix` is deprecated and `--glob-archives` should be used instead (https://borgbackup.readthedocs.io/en/stable/usage/prune.html). This patch adds a GLOB env var but leaves the PREFIX env var in place for backward compatibility. 